### PR TITLE
記事作成ページを実装

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,7 +9,7 @@
       <v-spacer></v-spacer>
 
       <template v-if="isSignedIn">
-        <nuxt-link to="/">
+        <nuxt-link to="/writing_article">
           <v-btn text :class="$style.register">投稿する</v-btn>
         </nuxt-link>
         <v-btn text :class="$style.login" @click="signOut">ログアウト</v-btn>

--- a/pages/writing_article.vue
+++ b/pages/writing_article.vue
@@ -1,0 +1,65 @@
+<template>
+  <form id="writing-article" :class="$style.article_form">
+    <v-text-field
+      v-model="title"
+      outlined
+      single-line
+      name="title"
+      placeholder="タイトル"
+      :class="$style.title_form"
+    ></v-text-field>
+    <div :class="$style.edit_area">
+      <v-textarea
+        v-model="body"
+        outlined
+        no-resize
+        hide-details
+        height="100%"
+        name="body"
+        placeholder="記事の内容を入力してください"
+        class="body-form"
+      ></v-textarea>
+    </div>
+    <div :class="$style.create_btn_area">
+      <v-btn color="#3085DE" class="font-weight-bold white--text"
+        >記事を投稿
+      </v-btn>
+    </div>
+  </form>
+</template>
+
+<style lang="scss" module>
+.article_form {
+  margin: 5px;
+  height: calc(100% - 64px - 10px);
+  display: flex;
+  flex-flow: column;
+  width: 100%;
+}
+
+.title_form {
+  flex: none;
+  background: #fff;
+}
+
+.edit_area {
+  height: 100%;
+  display: flex;
+  overflow: hidden;
+  background: #fff;
+  margin-bottom: 10px;
+}
+
+.create_btn_area {
+  text-align: right;
+}
+</style>
+
+<style lang="scss">
+#writing-article {
+  body-form > .v-text-field fieldset,
+  .v-text-field .v-input__control {
+    height: 100%;
+  }
+}
+</style>

--- a/pages/writing_article.vue
+++ b/pages/writing_article.vue
@@ -21,12 +21,53 @@
       ></v-textarea>
     </div>
     <div :class="$style.create_btn_area">
-      <v-btn color="#3085DE" class="font-weight-bold white--text"
+      <v-btn
+        color="#3085DE"
+        class="font-weight-bold white--text"
+        @click="createArticle"
         >記事を投稿
       </v-btn>
     </div>
   </form>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      id: '',
+      title: '',
+      body: '',
+      loading: false,
+    }
+  },
+
+  methods: {
+    async createArticle() {
+      this.loading = true
+
+      const params = {
+        title: this.title,
+        body: this.body,
+        status: 'published',
+      }
+
+      await this.$store
+        .dispatch('article/createArticle', params)
+        .then(() => {
+          this.$router.push('/')
+        })
+        .catch((e) => {
+          // 暫定的な Error 表示
+          alert(e.response.data.errors.full_messages)
+        })
+        .finally(() => {
+          this.loading = false
+        })
+    },
+  },
+}
+</script>
 
 <style lang="scss" module>
 .article_form {

--- a/store/article.js
+++ b/store/article.js
@@ -20,4 +20,8 @@ export const actions = {
       commit('setArticles', data)
     })
   },
+
+  async createArticle(_, params) {
+    await this.$axios.post('api/v1/articles', params)
+  },
 }


### PR DESCRIPTION
## 概要
- 記事作成ページから記事が投稿できるように実装

## 補足
API の仕様により記事の status を指定しない場合は下書き状態の記事になってしまい、
トップページに表示されなくなってしまうので注意してください。

##  対象の API
- [api/v1/articles_controller.rb](https://github.com/keita-naito/wonderful_editor/blob/master/app/controllers/api/v1/articles_controller.rb)