### PR TITLE
データの永続化の方法を LocalStorage から Cookie に変更する

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@nuxtjs/axios": "^5.12.2",
     "@nuxtjs/pwa": "^3.0.2",
     "core-js": "^3.6.5",
+    "js-cookie": "^2.2.1",
     "nuxt": "^2.14.6",
     "vue-timeago": "^5.1.3",
     "vuex-persistedstate": "^4.0.0-beta.3"

--- a/plugins/cookie-storage.js
+++ b/plugins/cookie-storage.js
@@ -1,9 +1,37 @@
 import createPersistedState from 'vuex-persistedstate'
+import * as Cookies from 'js-cookie'
 
-export default ({ store }) => {
-  window.onNuxtReady(() => {
-    createPersistedState({
-      key: 'wonderful-editor-frontend',
-    })(store)
-  })
+const COOKIE_TARGET_STORE = ['user']
+
+function filterValues(serializedJsonValue) {
+  const parsed = JSON.parse(serializedJsonValue)
+  const storeNames = Object.keys(parsed)
+
+  // 削除対象の store 一覧から cookie 保存する store を除外する
+  for (const storeName of COOKIE_TARGET_STORE) {
+    const idx = storeNames.indexOf(storeName)
+    storeNames.splice(idx, 1)
+  }
+
+  for (const key of storeNames) {
+    delete parsed[key]
+  }
+  return JSON.stringify(parsed)
+}
+
+export default ({ store, isDev }) => {
+  createPersistedState({
+    key: 'wonderful-editor-frontend',
+    storage: {
+      getItem: (key) => Cookies.get(key),
+      setItem: (key, value) =>
+        Cookies.set(
+          key,
+          filterValues(value),
+          { expires: 30, secure: !isDev },
+          { samesite: 'lax' }
+        ),
+      removeItem: (key) => Cookies.remove(key),
+    },
+  })(store)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6963,6 +6963,11 @@ js-beautify@^1.6.12, js-beautify@^1.6.14:
     mkdirp "^1.0.4"
     nopt "^5.0.0"
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
## 概要
- タイトルの通り

## 内容
リダイレクト処理を middleware を入れて実装しようとしたところ、LocalStorage だと mounted 後に読み込みが走る関係で使い物にならず、別途調整が必要になってしまったので Cookie を採用することにしました。

## 参考
- https://github.com/robinvdvleuten/vuex-persistedstate
- https://github.com/js-cookie/js-cookie