### PR TITLE
記事詳細ページを実装

### DIFF
--- a/pages/articles/_id/index.vue
+++ b/pages/articles/_id/index.vue
@@ -1,21 +1,23 @@
 <template>
   <v-container class="elevation-3" :class="$style.article_container">
-    <div :class="$style.article_layout">
-      <div :class="$style.name_area">
-        <span :class="$style.user_name">@{{ userName }}</span>
-        <timeago
-          :class="$style.time_ago"
-          :datetime="article.updated_at"
-          :auto-update="60"
-        />
-      </div>
-      <h1 :class="$style.article_title">{{ article.title }}</h1>
-      <div :class="$style.article_body_container">
-        <div :class="$style.article_body">
-          <p>{{ article.body }}</p>
+    <template v-if="isInitialized">
+      <div :class="$style.article_layout">
+        <div :class="$style.name_area">
+          <span :class="$style.user_name">@{{ article.user.name }}</span>
+          <timeago
+            :class="$style.time_ago"
+            :datetime="article.updated_at"
+            :auto-update="60"
+          />
+        </div>
+        <h1 :class="$style.article_title">{{ article.title }}</h1>
+        <div :class="$style.article_body_container">
+          <div :class="$style.article_body">
+            <p>{{ article.body }}</p>
+          </div>
         </div>
       </div>
-    </div>
+    </template>
   </v-container>
 </template>
 
@@ -23,18 +25,23 @@
 export default {
   middleware: ['authed'],
 
+  data() {
+    return {
+      isInitialized: false,
+    }
+  },
+
   computed: {
     article() {
       return this.$store.getters['article/article']
-    },
-    userName() {
-      return this.$store.getters['article/userName']
     },
   },
 
   async created() {
     const articleId = this.$route.params.id
-    await this.$store.dispatch('article/fetchArticle', articleId)
+    await this.$store.dispatch('article/fetchArticle', articleId).then(() => {
+      this.isInitialized = true
+    })
   },
 }
 </script>

--- a/pages/articles/_id/index.vue
+++ b/pages/articles/_id/index.vue
@@ -1,0 +1,56 @@
+<template>
+  <v-container class="elevation-3" :class="$style.article_container">
+    <div :class="$style.article_layout">
+      <div :class="$style.name_area">
+        <span>@{{ article.user.name }}</span>
+      </div>
+      <h1 :class="$style.article_title">{{ article.title }}</h1>
+      <div :class="$style.article_body_container">
+        <div :class="$style.article_body">
+          <p>{{ article.body }}</p>
+        </div>
+      </div>
+    </div>
+  </v-container>
+</template>
+
+<script>
+export default {
+  middleware: ['authed'],
+
+  data() {
+    return {
+      article: {
+        title: 'title',
+        body: '本文です',
+        user: { name: 'test' },
+      },
+    }
+  },
+}
+</script>
+
+<style lang="scss" module>
+.article_container {
+  margin-top: 30px;
+  background: #fff;
+  margin-bottom: 20px;
+}
+.article_layout {
+  margin: 0 20px;
+}
+.name_area {
+  margin-bottom: 16px;
+}
+.article_title {
+  font-size: 40px;
+  line-height: 1.5;
+}
+.article_body_container {
+  margin: 36px 0;
+  font-size: 16px;
+}
+.article_body {
+  width: 100%;
+}
+</style>

--- a/pages/articles/_id/index.vue
+++ b/pages/articles/_id/index.vue
@@ -2,7 +2,12 @@
   <v-container class="elevation-3" :class="$style.article_container">
     <div :class="$style.article_layout">
       <div :class="$style.name_area">
-        <span>@{{ article.user.name }}</span>
+        <span :class="$style.user_name">@{{ userName }}</span>
+        <timeago
+          :class="$style.time_ago"
+          :datetime="article.updated_at"
+          :auto-update="60"
+        />
       </div>
       <h1 :class="$style.article_title">{{ article.title }}</h1>
       <div :class="$style.article_body_container">
@@ -18,14 +23,18 @@
 export default {
   middleware: ['authed'],
 
-  data() {
-    return {
-      article: {
-        title: 'title',
-        body: '本文です',
-        user: { name: 'test' },
-      },
-    }
+  computed: {
+    article() {
+      return this.$store.getters['article/article']
+    },
+    userName() {
+      return this.$store.getters['article/userName']
+    },
+  },
+
+  async created() {
+    const articleId = this.$route.params.id
+    await this.$store.dispatch('article/fetchArticle', articleId)
   },
 }
 </script>
@@ -35,12 +44,16 @@ export default {
   margin-top: 30px;
   background: #fff;
   margin-bottom: 20px;
+  width: 60%;
 }
 .article_layout {
   margin: 0 20px;
 }
 .name_area {
   margin-bottom: 16px;
+}
+.user_name {
+  margin-right: 16px;
 }
 .article_title {
   font-size: 40px;
@@ -52,5 +65,6 @@ export default {
 }
 .article_body {
   width: 100%;
+  white-space: pre-wrap;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,7 +8,10 @@
           </v-list-item-avatar>
           <v-list-item-content>
             <v-list-item-title :class="$style.article_title">
-              <nuxt-link to="/">{{ article.title }}</nuxt-link>
+              <nuxt-link
+                :to="{ name: 'articles-id', params: { id: article.id } }"
+                >{{ article.title }}</nuxt-link
+              >
             </v-list-item-title>
             <v-list-item-subtitle :class="$style.user_name">
               by {{ article.user.name }}

--- a/store/article.js
+++ b/store/article.js
@@ -1,14 +1,20 @@
 export const state = () => ({
   articles: [],
+  article: {},
 })
 
 export const getters = {
   articles: (state) => state.articles,
+  article: (state) => state.article,
+  userName: (state) => state.article?.user?.name,
 }
 
 export const mutations = {
   setArticles(state, articles) {
     state.articles = articles
+  },
+  setArticle(state, article) {
+    state.article = article
   },
 }
 
@@ -18,6 +24,14 @@ export const actions = {
       const data = response.data
 
       commit('setArticles', data)
+    })
+  },
+
+  async fetchArticle({ commit }, id) {
+    await this.$axios.get(`api/v1/articles/${id}`).then((response) => {
+      const data = response.data
+
+      commit('setArticle', data)
     })
   },
 

--- a/store/article.js
+++ b/store/article.js
@@ -6,7 +6,6 @@ export const state = () => ({
 export const getters = {
   articles: (state) => state.articles,
   article: (state) => state.article,
-  userName: (state) => state.article?.user?.name,
 }
 
 export const mutations = {


### PR DESCRIPTION
## 概要
- 記事一覧のタイトルにリンクを設定して記事詳細ページを追加

## 内容
- ルーティングは記事の ID で動的になるように調整

## 補足
- 現時点ではマークダウンやシンタックスハイライトなどの設定はありません。